### PR TITLE
[#3] 뉴스피드 조회 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
+application.properties
 .idea
 *.iws
 *.iml
@@ -37,3 +38,6 @@ out/
 .vscode/
 
 src/main/resources/.env
+
+### Mac OS ###
+.DS_Store

--- a/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
+++ b/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/auth/login", "/auth/reissue", "/users/signup").permitAll()
+                .requestMatchers("/auth/login", "/auth/reissue", "/users/signup", "/posts").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                 UsernamePasswordAuthenticationFilter.class

--- a/src/main/java/org/example/postory/domain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/postory/domain/jwt/JwtAuthenticationFilter.java
@@ -18,7 +18,7 @@ import org.springframework.web.filter.GenericFilterBean;
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtProvider jwtTokenProvider;
-    private static final String[] WHITELIST = {"/", "/users/signup", "/auth/login"};
+    private static final String[] WHITELIST = {"/", "/users/signup", "/auth/login", "/posts"};
 
     /**
      * 1. Request Header에서 JWT 토큰 추출

--- a/src/main/java/org/example/postory/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/postory/domain/post/controller/PostController.java
@@ -1,15 +1,18 @@
 package org.example.postory.domain.post.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.example.postory.domain.post.dto.PostResponseDto;
 import org.example.postory.domain.post.entity.Post;
 import org.example.postory.domain.post.repository.PostRepository;
 import org.example.postory.domain.post.service.PostService;
+import org.example.postory.global.common.pagination.CursorResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -32,6 +35,16 @@ public class PostController {
 
         Post post = postService.getPostById(id, userId); // 첫번째 매개변수 : @PathVariable 에서 온 게시물 id
         return ResponseEntity.ok(PostResponseDto.fromPostEntity(post));
+    }
+
+    // 뉴스피드 조회
+    @GetMapping
+    public ResponseEntity<CursorResponseDto<PostResponseDto>> getNewsFeed(
+        @RequestParam(required = false)LocalDateTime cursorUpdatedAt,
+        @RequestParam(required = false)Long cursorId
+    ) {
+        CursorResponseDto<PostResponseDto> newsFeedResponse = postService.getNewsFeed(cursorUpdatedAt, cursorId);
+        return ResponseEntity.ok(newsFeedResponse);
     }
 
 }

--- a/src/main/java/org/example/postory/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/postory/domain/post/controller/PostController.java
@@ -9,6 +9,7 @@ import org.example.postory.domain.post.dto.PostResponseDto.SingleQuery;
 import org.example.postory.domain.post.entity.Post;
 import org.example.postory.domain.post.service.PostService;
 import org.example.postory.global.common.pagination.CursorResponseDto;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -45,7 +46,7 @@ public class PostController {
         @RequestParam(required = false)Long cursorId
     ) {
         CursorResponseDto<NewsFeed> newsFeedResponse = postService.getNewsFeed(cursorUpdatedAt, cursorId);
-        return ResponseEntity.ok(newsFeedResponse);
+        return ResponseEntity.status(HttpStatus.CREATED).body(postService.getNewsFeed(cursorUpdatedAt, cursorId));
     }
 
 }

--- a/src/main/java/org/example/postory/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/postory/domain/post/controller/PostController.java
@@ -43,10 +43,10 @@ public class PostController {
     @GetMapping
     public ResponseEntity<CursorResponseDto<NewsFeed>> getNewsFeed(
         @RequestParam(required = false)LocalDateTime cursorUpdatedAt,
-        @RequestParam(required = false)Long cursorId
+        @RequestParam(required = false)Long cursorId,
+        @RequestParam(defaultValue = "10")int size
     ) {
-        CursorResponseDto<NewsFeed> newsFeedResponse = postService.getNewsFeed(cursorUpdatedAt, cursorId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(postService.getNewsFeed(cursorUpdatedAt, cursorId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(postService.getNewsFeed(cursorUpdatedAt, cursorId, size));
     }
 
 }

--- a/src/main/java/org/example/postory/domain/post/controller/PostController.java
+++ b/src/main/java/org/example/postory/domain/post/controller/PostController.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.example.postory.domain.post.dto.PostResponseDto;
-import org.example.postory.domain.post.dto.PostResponseDto.ProfileInquiry;
+import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 import org.example.postory.domain.post.dto.PostResponseDto.SingleQuery;
 import org.example.postory.domain.post.entity.Post;
 import org.example.postory.domain.post.service.PostService;
@@ -40,11 +40,11 @@ public class PostController {
 
     // 뉴스피드 조회
     @GetMapping
-    public ResponseEntity<CursorResponseDto<ProfileInquiry>> getNewsFeed(
+    public ResponseEntity<CursorResponseDto<NewsFeed>> getNewsFeed(
         @RequestParam(required = false)LocalDateTime cursorUpdatedAt,
         @RequestParam(required = false)Long cursorId
     ) {
-        CursorResponseDto<ProfileInquiry> newsFeedResponse = postService.getNewsFeed(cursorUpdatedAt, cursorId);
+        CursorResponseDto<NewsFeed> newsFeedResponse = postService.getNewsFeed(cursorUpdatedAt, cursorId);
         return ResponseEntity.ok(newsFeedResponse);
     }
 

--- a/src/main/java/org/example/postory/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/org/example/postory/domain/post/dto/PostResponseDto.java
@@ -1,6 +1,5 @@
 package org.example.postory.domain.post.dto;
 
-import com.fasterxml.jackson.core.JsonToken;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
@@ -12,7 +11,7 @@ public class PostResponseDto {
 
     @Getter
     @RequiredArgsConstructor
-    public static class ProfileInquiry{
+    public static class NewsFeed{
         private final Long id;
         private final String title;
         private final String content;
@@ -23,7 +22,7 @@ public class PostResponseDto {
         private final LocalDateTime createAt;
         private final boolean isUpdated;
 
-        public ProfileInquiry(Post post) {
+        public NewsFeed(Post post) {
             this.id = post.getId();
             this.title = post.getTitle();
             this.content = post.getContent();

--- a/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
@@ -1,6 +1,9 @@
 package org.example.postory.domain.post.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.example.postory.domain.post.entity.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,5 +26,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     """)
     Optional<Post> findVisiblePost(@Param("id") Long id, @Param("userId") Long userId);
 
+
+    @Query("""
+        SELECT p FROM Post p
+        WHERE ((p.updatedAt < :cursorUpdatedAt)
+        OR (p.updatedAt = :cursorUpdatedAt AND p.id < :cursorId))
+        AND p.isPublic = true
+        ORDER BY p.updatedAt DESC, p.id DESC
+    """)
+    List<Post> getNewsFeed(
+        @Param("cursorUpdatedAt") LocalDateTime cursorUpdatedAt,
+        @Param("cursorId") Long cursorId,
+        Pageable pageable
+    );
 
 }

--- a/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
@@ -52,6 +52,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
         WHERE ((p.updatedAt < :cursorUpdatedAt)
         OR (p.updatedAt = :cursorUpdatedAt AND p.id < :cursorId))
         AND p.isPublic = true
+        AND p.deletedAt IS NULL
         ORDER BY p.updatedAt DESC, p.id DESC
     """)
     List<Post> getNewsFeed(

--- a/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
@@ -1,7 +1,7 @@
 package org.example.postory.domain.post.repository;
 
 import java.time.LocalDateTime;
-import org.example.postory.domain.post.dto.PostResponseDto.ProfileInquiry;
+import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 import org.example.postory.domain.post.entity.Post;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,18 +33,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     //공개 게시글 + 삭제되지 않은 게시글 + 수정일 기준 최신순 정렬
     List<Post> getAllByUser_IdAndDeletedAtIsNullAndIsPublicIsTrueOrderByUpdatedAt(Long userId);
 
-    default List<ProfileInquiry> getVisiblePostsByUser(Long userId) {
+    default List<NewsFeed> getVisiblePostsByUser(Long userId) {
         return getAllByUser_IdAndDeletedAtIsNullAndIsPublicIsTrueOrderByUpdatedAt(userId)
-            .stream().map(PostResponseDto.ProfileInquiry::new).collect(Collectors.toList());
+            .stream().map(PostResponseDto.NewsFeed::new).collect(Collectors.toList());
     }
 
 
     List<Post> getAllByUser_IdAndDeletedAtIsNullOrderByUpdatedAt(Long userId);
 
     // 삭제되지 않은 게시글 + 수정일 기준 최신 정렬 ( 함수이름 가독성이 좋지않아서 따로 함더감쌌음)
-    default List<ProfileInquiry> getAllMyPosts(Long userId){
+    default List<NewsFeed> getAllMyPosts(Long userId){
         return getAllByUser_IdAndDeletedAtIsNullOrderByUpdatedAt(userId)
-            .stream().map(PostResponseDto.ProfileInquiry::new).collect(Collectors.toList());
+            .stream().map(PostResponseDto.NewsFeed::new).collect(Collectors.toList());
     }
 
     @Query("""

--- a/src/main/java/org/example/postory/domain/post/service/PostService.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostService.java
@@ -1,10 +1,16 @@
 package org.example.postory.domain.post.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import org.example.postory.domain.post.dto.PostResponseDto;
 import org.example.postory.domain.post.entity.Post;
+import org.example.postory.global.common.pagination.CursorResponseDto;
 
 public interface PostService {
 
     // 게시물 id와 사용자 id로 게시물 조회
     Post getPostById(long postId, Long userId);
+
+    CursorResponseDto<PostResponseDto> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId);
 
 }

--- a/src/main/java/org/example/postory/domain/post/service/PostService.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostService.java
@@ -9,7 +9,7 @@ public interface PostService {
 
     // 게시물 id와 사용자 id로 게시물 조회
     Post getPostById(long postId, Long userId);
-
-    CursorResponseDto<NewsFeed> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId);
+    // 뉴스피드 조회
+    CursorResponseDto<NewsFeed> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId, int size);
 
 }

--- a/src/main/java/org/example/postory/domain/post/service/PostService.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostService.java
@@ -1,9 +1,7 @@
 package org.example.postory.domain.post.service;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import org.example.postory.domain.post.dto.PostResponseDto;
-import org.example.postory.domain.post.dto.PostResponseDto.ProfileInquiry;
+import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 import org.example.postory.domain.post.entity.Post;
 import org.example.postory.global.common.pagination.CursorResponseDto;
 
@@ -12,6 +10,6 @@ public interface PostService {
     // 게시물 id와 사용자 id로 게시물 조회
     Post getPostById(long postId, Long userId);
 
-    CursorResponseDto<ProfileInquiry> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId);
+    CursorResponseDto<NewsFeed> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId);
 
 }

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -1,10 +1,17 @@
 package org.example.postory.domain.post.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.example.postory.domain.post.dto.PostResponseDto;
 import org.example.postory.domain.post.entity.Post;
 import org.example.postory.domain.post.repository.PostRepository;
+import org.example.postory.global.common.pagination.CursorDto;
+import org.example.postory.global.common.pagination.CursorResponseDto;
 import org.example.postory.global.error.ApiException;
 import org.example.postory.global.error.response.ErrorType;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
@@ -22,5 +29,32 @@ public class PostServiceImpl implements PostService {
         // 결과는 Optional<Post> 형식으로 반환되며, 값이 존재하면 그 값을 꺼내서 return
         // 빈 Optional이 나오면 orElseThrow로 값 던지기
     }
+
+    @Override
+    public CursorResponseDto<PostResponseDto> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId) {
+
+        // 첫 번째 조회.
+        if (cursorUpdatedAt == null || cursorId == null) {
+            cursorUpdatedAt = LocalDateTime.now();
+            cursorId = Long.MAX_VALUE;
+        }
+
+        // 한 번에 10개씩 가져오도록 고정.
+        Pageable pageable = PageRequest.of(0, 10);
+
+        List<Post> newsFeed = postRepository.getNewsFeed(cursorUpdatedAt, cursorId, pageable);
+        List<PostResponseDto> newsFeedDto = newsFeed.stream().map(PostResponseDto::fromPostEntity).toList();
+
+        // 다음 커서 정보 저장
+        CursorDto nextCursor = null;
+        if (!newsFeed.isEmpty()) {
+            Post lastFeed = newsFeed.get(newsFeed.size() - 1);
+            nextCursor = new CursorDto(lastFeed.getUpdatedAt(), lastFeed.getId());
+        }
+
+        return CursorResponseDto.of(newsFeedDto, nextCursor);
+
+    }
+
 
 }

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -3,8 +3,7 @@ package org.example.postory.domain.post.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.example.postory.domain.post.dto.PostResponseDto;
-import org.example.postory.domain.post.dto.PostResponseDto.ProfileInquiry;
+import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 import org.example.postory.domain.post.entity.Post;
 import org.example.postory.domain.post.repository.PostRepository;
 import org.example.postory.global.common.pagination.CursorDto;
@@ -14,8 +13,6 @@ import org.example.postory.global.error.response.ErrorType;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor // 생성자 주입
@@ -32,7 +29,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public CursorResponseDto<ProfileInquiry> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId) {
+    public CursorResponseDto<NewsFeed> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId) {
 
         // 첫 번째 조회.
         if (cursorUpdatedAt == null || cursorId == null) {
@@ -44,7 +41,7 @@ public class PostServiceImpl implements PostService {
         Pageable pageable = PageRequest.of(0, 10);
 
         List<Post> newsFeed = postRepository.getNewsFeed(cursorUpdatedAt, cursorId, pageable);
-        List<ProfileInquiry> newsFeedDto = newsFeed.stream().map(ProfileInquiry::new).toList();
+        List<NewsFeed> newsFeedDto = newsFeed.stream().map(NewsFeed::new).toList();
 
         // 다음 커서 정보 저장
         CursorDto nextCursor = null;

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -29,7 +29,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public CursorResponseDto<NewsFeed> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId) {
+    public CursorResponseDto<NewsFeed> getNewsFeed(LocalDateTime cursorUpdatedAt, Long cursorId, int size) {
 
         // 첫 번째 조회.
         if (cursorUpdatedAt == null || cursorId == null) {
@@ -38,7 +38,7 @@ public class PostServiceImpl implements PostService {
         }
 
         // 한 번에 10개씩 가져오도록 고정.
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, size);
 
         List<Post> newsFeed = postRepository.getNewsFeed(cursorUpdatedAt, cursorId, pageable);
         List<NewsFeed> newsFeedDto = newsFeed.stream().map(NewsFeed::new).toList();

--- a/src/main/java/org/example/postory/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/org/example/postory/domain/user/dto/UserProfileResponseDto.java
@@ -3,8 +3,7 @@ package org.example.postory.domain.user.dto;
 
 import java.util.List;
 import lombok.Getter;
-import org.example.postory.domain.post.dto.PostResponseDto;
-import org.example.postory.domain.post.dto.PostResponseDto.ProfileInquiry;
+import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 
 /**
  * 유저 프로필 반환하는 Dto
@@ -28,10 +27,10 @@ public class UserProfileResponseDto {
 
     private final int postCount;
 
-    private final List<ProfileInquiry> postList;
+    private final List<NewsFeed> postList;
 
     public UserProfileResponseDto(Long id, String username, String introduction, boolean isPublic,
-        int followingCnt, int followerCnt, List<ProfileInquiry> postList) {
+        int followingCnt, int followerCnt, List<NewsFeed> postList) {
         this.id = id;
         this.username = username;
         this.introduction = introduction;
@@ -43,7 +42,7 @@ public class UserProfileResponseDto {
     }
 
     public UserProfileResponseDto(Long id, String username, String introduction, boolean isPublic,
-        int followingCnt, int followerCnt, boolean isFollowing, List<ProfileInquiry> postList) {
+        int followingCnt, int followerCnt, boolean isFollowing, List<NewsFeed> postList) {
         this.id = id;
         this.username = username;
         this.introduction = introduction;

--- a/src/main/java/org/example/postory/domain/user/entity/User.java
+++ b/src/main/java/org/example/postory/domain/user/entity/User.java
@@ -9,7 +9,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
@@ -1,15 +1,12 @@
 package org.example.postory.domain.user.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 import org.example.postory.domain.user.dto.SignupRequestDto;
 import org.example.postory.domain.user.dto.SignupResponseDto;
 import org.example.postory.global.util.PasswordEncoder;
 import static org.example.postory.global.error.response.ErrorType.*;
-import org.example.postory.domain.post.dto.PostResponseDto;
-import org.example.postory.domain.post.dto.PostResponseDto.ProfileInquiry;
-import org.example.postory.domain.post.entity.Post;
 import org.example.postory.domain.post.repository.PostRepository;
 import org.example.postory.domain.user.dto.UserProfileResponseDto;
 import org.example.postory.domain.user.entity.User;
@@ -20,8 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-import org.example.postory.global.error.ApiException;
-import org.example.postory.global.error.response.ErrorType;
 
 @Service
 @RequiredArgsConstructor
@@ -106,7 +101,7 @@ public class UserServiceImpl implements UserService{
 
         if(loginUserId.equals(UserId)){
             //게시글 가져오기 - 자기자신의 프로필이라 isn't public 한 게시글도 다 불러옴
-            List<ProfileInquiry> posts = postRepository.getAllMyPosts(UserId);
+            List<NewsFeed> posts = postRepository.getAllMyPosts(UserId);
 
             return new UserProfileResponseDto(
                 user.getId(),
@@ -118,7 +113,7 @@ public class UserServiceImpl implements UserService{
                 posts
             );
         }else{
-            List<ProfileInquiry> posts = postRepository.getVisiblePostsByUser(UserId);
+            List<NewsFeed> posts = postRepository.getVisiblePostsByUser(UserId);
 
             return new UserProfileResponseDto(
                 user.getId(),

--- a/src/main/java/org/example/postory/global/common/pagination/CursorDto.java
+++ b/src/main/java/org/example/postory/global/common/pagination/CursorDto.java
@@ -1,0 +1,16 @@
+package org.example.postory.global.common.pagination;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class CursorDto {
+
+    private final LocalDateTime updatedAt;
+    private final Long id;
+
+    public CursorDto(LocalDateTime updatedAt, Long id) {
+        this.updatedAt = updatedAt;
+        this.id = id;
+    }
+}

--- a/src/main/java/org/example/postory/global/common/pagination/CursorResponseDto.java
+++ b/src/main/java/org/example/postory/global/common/pagination/CursorResponseDto.java
@@ -1,0 +1,21 @@
+package org.example.postory.global.common.pagination;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CursorResponseDto<T> {
+
+    private final List<T> data;
+    private final CursorDto nextCursor;
+
+    public CursorResponseDto(List<T> data, CursorDto nextCursor) {
+        this.data = data;
+        this.nextCursor = nextCursor;
+    }
+
+    public static <T> CursorResponseDto<T> of(List<T> data, CursorDto nextCursor) {
+        return new CursorResponseDto<>(data, nextCursor);
+    }
+
+}

--- a/src/main/java/org/example/postory/global/error/response/ErrorType.java
+++ b/src/main/java/org/example/postory/global/error/response/ErrorType.java
@@ -30,7 +30,7 @@ public enum ErrorType implements ExceptionStatus {
      * 2000: user 에러
      */
     USER_NOT_FOUND(2001, HttpStatus.NOT_FOUND.value(), "존재하지 않는 사용자입니다."),
-    EMAIL_NOT_FOUND(2002, HttpStatus.NOT_FOUND.value(), "존재하지 않는 이메일입니다.")
+    EMAIL_NOT_FOUND(2002, HttpStatus.NOT_FOUND.value(), "존재하지 않는 이메일입니다."),
 
     /**
      * 3000: post 에러

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+spring.application.name=postory


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/3 -> dev

### 변경 사항
+ 뉴스피드 조회 기능을 커서 방식으로 개발했습니다.
+ 로그인 했을 때 팔로워의 게시글만 뉴스피드로 보여주는 기능은 아직 고려하지 않았습니다.
+ 로그인 전 뉴스피드만 조회 가능하기 때문에 requestMatchers 와 WHITELIST에 "/posts" 경로를 추가했습니다.

### 테스트 결과
<img width="1274"  src="https://github.com/user-attachments/assets/233d7162-8533-444c-8a03-a92f2d7a062a" />

