### PR TITLE
[#27] feat: 팔로우/팔로워 목록 조회 api 구현

### DIFF
--- a/src/main/java/org/example/postory/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/postory/domain/auth/controller/AuthController.java
@@ -3,7 +3,7 @@ package org.example.postory.domain.auth.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.postory.domain.auth.dto.AuthRequestDto;
-import org.example.postory.domain.auth.jwt.JwtToken;
+import org.example.postory.domain.auth.dto.JwtToken;
 import org.example.postory.domain.auth.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/example/postory/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/postory/domain/user/controller/UserController.java
@@ -1,25 +1,16 @@
 package org.example.postory.domain.user.controller;
 
-import org.example.postory.domain.user.dto.UserRequestDto;
-import org.example.postory.domain.user.dto.UserResponseDto;
+import org.example.postory.domain.user.dto.*;
+import org.example.postory.global.common.pagination.CursorResponseDto;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.postory.domain.user.dto.SignupRequestDto;
-import org.example.postory.domain.user.dto.SignupResponseDto;
-import org.example.postory.domain.user.dto.UserProfileResponseDto;
 import org.example.postory.domain.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -72,6 +63,28 @@ public class UserController {
     ) {
         userService.unfollow(Long.parseLong(userDetail.getUsername()), followingId);
         return ResponseEntity.status(HttpStatus.OK).body("언팔로우 성공");
+    }
+
+    @GetMapping("/following/{userId}")
+    public ResponseEntity<CursorResponseDto<FollowingResponseDto>> getFollowing(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long userId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userService.getFollowing(Long.parseLong(userDetails.getUsername()), userId, cursorId, size));
+    }
+
+    @GetMapping("/followers/{userId}")
+    public ResponseEntity<CursorResponseDto<FollowingResponseDto>> getFollowers(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long userId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userService.getFollowers(Long.parseLong(userDetails.getUsername()), userId, cursorId, size));
     }
 }
 

--- a/src/main/java/org/example/postory/domain/user/dto/FollowingResponseDto.java
+++ b/src/main/java/org/example/postory/domain/user/dto/FollowingResponseDto.java
@@ -1,0 +1,11 @@
+package org.example.postory.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowingResponseDto {
+    private Long userId;
+    private String name;
+}

--- a/src/main/java/org/example/postory/domain/user/entity/Following.java
+++ b/src/main/java/org/example/postory/domain/user/entity/Following.java
@@ -10,8 +10,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Following {

--- a/src/main/java/org/example/postory/domain/user/repository/FollowingRepository.java
+++ b/src/main/java/org/example/postory/domain/user/repository/FollowingRepository.java
@@ -1,8 +1,11 @@
 package org.example.postory.domain.user.repository;
 
 import org.example.postory.domain.user.entity.Following;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FollowingRepository extends JpaRepository<Following, Long> {
@@ -13,7 +16,23 @@ public interface FollowingRepository extends JpaRepository<Following, Long> {
     //팔로워 수 반환
     Long countByFollowingUser_id(Long followingUserId);
 
-    boolean existsByFollowingUserIdAndUserId(Long userId, Long followingUserId);
+    boolean existsByUserIdAndFollowingUserId(Long userId, Long followingUserId);
 
     Optional<Integer> deleteByUserIdAndFollowingUserId(Long userId, Long followingUserId);
+
+    @Query("""
+        SELECT f FROM Following f
+        WHERE f.user.id = :userId
+            AND f.id < :cursorId
+        ORDER BY f.id DESC
+    """)
+    List<Following> findFollowingsByCursor(Long userId, Long cursorId, Pageable pageable);
+
+    @Query("""
+        SELECT f FROM Following f
+        WHERE f.followingUser.id = :userId
+            AND f.id < :cursorId
+        ORDER BY f.id DESC
+    """)
+    List<Following> findFollowersByCursor(Long userId, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/org/example/postory/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/postory/domain/user/repository/UserRepository.java
@@ -2,10 +2,16 @@ package org.example.postory.domain.user.repository;
 
 import static org.example.postory.global.error.response.ErrorType.USER_NOT_FOUND;
 
+import java.util.List;
 import java.util.Optional;
+
+import org.example.postory.domain.user.entity.Following;
 import org.example.postory.domain.user.entity.User;
 import org.example.postory.global.error.ApiException;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 public interface UserRepository extends JpaRepository<User, Long> {

--- a/src/main/java/org/example/postory/domain/user/service/UserService.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserService.java
@@ -1,11 +1,9 @@
 package org.example.postory.domain.user.service;
 
-import org.example.postory.domain.user.dto.SignupRequestDto;
-import org.example.postory.domain.user.dto.SignupResponseDto;
-import org.example.postory.domain.user.dto.UserProfileResponseDto;
+import org.example.postory.domain.user.dto.*;
 import org.example.postory.domain.user.dto.UserRequestDto.UpdateProfile;
-import org.example.postory.domain.user.dto.UserResponseDto;
 import org.example.postory.domain.user.entity.User;
+import org.example.postory.global.common.pagination.CursorResponseDto;
 
 public interface UserService {
 
@@ -25,4 +23,7 @@ public interface UserService {
 
     UserResponseDto.UpdateProfile updateProfile(Long authUserId, UpdateProfile profile);
 
+    CursorResponseDto<FollowingResponseDto> getFollowing(Long authUserId, Long userId, Long cursorId, int size);
+
+    CursorResponseDto<FollowingResponseDto> getFollowers(Long authUserId, Long userId, Long cursorId, int size);
 }

--- a/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
@@ -5,21 +5,22 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 import org.example.postory.domain.post.repository.PostRepository;
-import org.example.postory.domain.user.dto.SignupRequestDto;
-import org.example.postory.domain.user.dto.SignupResponseDto;
+import org.example.postory.domain.user.dto.*;
 import org.example.postory.domain.user.dto.UserRequestDto.UpdateProfile;
-import org.example.postory.domain.user.dto.UserResponseDto;
+import org.example.postory.global.common.pagination.CursorDto;
+import org.example.postory.global.common.pagination.CursorResponseDto;
 import org.example.postory.global.util.PasswordEncoder;
 
 import static org.example.postory.global.error.response.ErrorType.*;
 
-import org.example.postory.domain.user.dto.UserProfileResponseDto;
 import org.example.postory.domain.user.entity.Following;
 import org.example.postory.domain.user.entity.User;
 import org.example.postory.domain.user.repository.FollowingRepository;
 import org.example.postory.domain.user.repository.UserRepository;
 import org.example.postory.global.error.ApiException;
 import org.example.postory.global.error.response.ErrorType;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,7 +91,7 @@ public class UserServiceImpl implements UserService {
     public UserProfileResponseDto getProfile(Long loginUserId, Long UserId) {
         User user = userRepository.findByUserIdOrElseThrow(UserId);
 
-        if (!loginUserId.equals(UserId) && !followingRepository.existsByFollowingUserIdAndUserId(
+        if (!loginUserId.equals(UserId) && !followingRepository.existsByUserIdAndFollowingUserId(
             loginUserId, UserId) && !user.isPublic()) {
             throw new ApiException(FORBIDDEN_PROFILE);
         }
@@ -110,7 +111,7 @@ public class UserServiceImpl implements UserService {
 
             return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
                 user.isPublic(), followingCnt.intValue(), followerCnt.intValue(),
-                followingRepository.existsByFollowingUserIdAndUserId(loginUserId, UserId), posts);
+                followingRepository.existsByUserIdAndFollowingUserId(loginUserId, UserId), posts);
         }
     }
 
@@ -150,18 +151,18 @@ public class UserServiceImpl implements UserService {
         return new UserResponseDto.UpdateProfile(savedUser);
     }
 
-    public void follow(Long userId, Long followingId) {
-        if (userId.equals(followingId)) {
+    public void follow(Long loginUserId, Long followingId) {
+        if (loginUserId.equals(followingId)) {
             throw new ApiException(ErrorType.CANNOT_FOLLOW_SELF);
         }
 
-        User user = userRepository.findById(userId)
+        User user = userRepository.findById(loginUserId)
                 .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
 
         User targetUser = userRepository.findById(followingId)
                 .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
 
-        if (followingRepository.existsByFollowingUserIdAndUserId(followingId, userId)) {
+        if (followingRepository.existsByUserIdAndFollowingUserId(loginUserId, followingId)) {
             throw new ApiException(ErrorType.ALREADY_FOLLOWING);
         }
 
@@ -174,18 +175,18 @@ public class UserServiceImpl implements UserService {
     }
 
     @Transactional
-    public void unfollow(Long userId, Long followingId) {
-        userRepository.findById(userId)
+    public void unfollow(Long loginUserId, Long followingId) {
+        userRepository.findById(loginUserId)
                 .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
 
         userRepository.findById(followingId)
                 .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
 
-        if (!followingRepository.existsByFollowingUserIdAndUserId(followingId, userId)) {
+        if (!followingRepository.existsByUserIdAndFollowingUserId(loginUserId, followingId)) {
             throw new ApiException(ErrorType.NOT_FOLLOWING);
         }
 
-        Integer count = followingRepository.deleteByUserIdAndFollowingUserId(userId, followingId)
+        Integer count = followingRepository.deleteByUserIdAndFollowingUserId(loginUserId, followingId)
                 .orElseThrow(() -> new ApiException(UNFOLLOW_FAILED));
 
         if (count != 1) {
@@ -193,6 +194,79 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    public CursorResponseDto<FollowingResponseDto> getFollowing(Long loginUserId, Long userId, Long cursorId, int size) {
+        userRepository.findById(loginUserId)
+                .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+
+        // 나 자신이 아니고 비공개이고 친구가 아니면 조회 불가
+        if (!loginUserId.equals(userId)
+                && !user.isPublic()
+                && !followingRepository.existsByUserIdAndFollowingUserId(loginUserId, userId)) {
+            throw new ApiException(FORBIDDEN_PROFILE);
+        }
+
+        // 나 자신이면 조회 가능, 나 자신이 아니고 비공개가 아니면 조회 가능, 나 자신이 아니고 비공개인데 친구이면 조회 가능
+        if (cursorId == null) {
+            cursorId = Long.MAX_VALUE;
+        }
+
+        Pageable pageable = PageRequest.of(0, size);
+
+        // 커서 기반으로 팔로잉 유저 목록 조회 (최근에 팔로우한 순)
+        List<Following> followings = followingRepository.findFollowingsByCursor(userId, cursorId, pageable);
+
+        List<FollowingResponseDto> followingResponseDtos = followings.stream()
+                .map(f -> new FollowingResponseDto(f.getFollowingUser().getId(), f.getFollowingUser().getName()))
+                .collect(Collectors.toList());
+
+        // 다음 커서 설정
+        CursorDto nextCursor = null;
+        if (!followings.isEmpty()) {
+            Long lastId = followings.get(followings.size() - 1).getId();
+            nextCursor = new CursorDto(lastId); // 팔로잉 목록은 정렬 기준이 최근 업데이트된 순이 아니라 팔로잉 순서이기 때문에 id만 사용
+        }
+
+        return CursorResponseDto.of(followingResponseDtos, nextCursor);
+    }
+
+    public CursorResponseDto<FollowingResponseDto> getFollowers(Long loginUserId, Long userId, Long cursorId, int size) {
+        userRepository.findById(loginUserId)
+                .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
+
+        // 나 자신이 아니고 비공개이고 친구가 아니면 조회 불가
+        if (!loginUserId.equals(userId)
+                && !user.isPublic()
+                && !followingRepository.existsByUserIdAndFollowingUserId(loginUserId, userId)) {
+            throw new ApiException(FORBIDDEN_PROFILE);
+        }
+
+        // 나 자신이면 조회 가능, 나 자신이 아니고 비공개가 아니면 조회 가능, 나 자신이 아니고 비공개인데 친구이면 조회 가능
+        if (cursorId == null) {
+            cursorId = Long.MAX_VALUE;
+        }
+
+        Pageable pageable = PageRequest.of(0, size);
+
+        // 커서 기반으로 팔로잉 유저 목록 조회 (최근에 팔로우한 순)
+        List<Following> followings = followingRepository.findFollowersByCursor(userId, cursorId, pageable);
+
+        List<FollowingResponseDto> followingResponseDtos = followings.stream()
+                .map(f -> new FollowingResponseDto(f.getUser().getId(), f.getUser().getName()))
+                .collect(Collectors.toList());
+
+        // 다음 커서 설정
+        CursorDto nextCursor = null;
+        if (!followings.isEmpty()) {
+            Long lastId = followings.get(followings.size() - 1).getId();
+            nextCursor = new CursorDto(lastId); // 팔로잉 목록은 정렬 기준이 최근 업데이트된 순이 아니라 팔로잉 순서이기 때문에 id만 사용
+        }
+
+        return CursorResponseDto.of(followingResponseDtos, nextCursor);
+    }
 
 }
 

--- a/src/main/java/org/example/postory/global/common/pagination/CursorDto.java
+++ b/src/main/java/org/example/postory/global/common/pagination/CursorDto.java
@@ -6,11 +6,15 @@ import lombok.Getter;
 @Getter
 public class CursorDto {
 
-    private final LocalDateTime updatedAt;
-    private final Long id;
+    private LocalDateTime updatedAt;
+    private Long id;
 
     public CursorDto(LocalDateTime updatedAt, Long id) {
         this.updatedAt = updatedAt;
+        this.id = id;
+    }
+
+    public CursorDto(Long id) {
         this.id = id;
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/27 -> develop

### 변경 사항


### 테스트 결과
**성공**
다른 사람 팔로잉/팔로워 목록 조회
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/19e4c80a-fecb-44f1-8f6b-4ad22f0d2911" />

자신의 팔로잉/팔로워 목록 조회
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/8d06689a-8a91-43f6-b9bf-417b2bc17035" />

**실패**
프로필 비공개 & 친구 아닌 사람의 팔로잉/팔로워 목록 조회
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/2f04e158-b438-4c43-9af7-57161ad6804a" />

존재하지 않는 사용자의 팔로잉/팔로워 목록 조회
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/93921349-e9ab-43ff-8046-7af20e135025" />
