### PR TITLE
[#52] fix: isPublic 필드명 변경

### DIFF
--- a/src/main/java/org/example/postory/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/comment/service/CommentServiceImpl.java
@@ -64,7 +64,7 @@ public class CommentServiceImpl implements CommentService {
         // 포스트의 공개 여부 확인
         Post post = postRepository.findById(postId)
             .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
-        if (!post.isPublic()) {
+        if (!post.isPostPublic()) {
             throw new ApiException(ErrorType.POST_NOT_PUBLIC);
         }
 

--- a/src/main/java/org/example/postory/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/org/example/postory/domain/post/dto/PostRequestDto.java
@@ -1,5 +1,6 @@
 package org.example.postory.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -21,7 +22,8 @@ public class PostRequestDto {
         @NotBlank(message = "내용은 필수 입력 항목입니다.")
         @Size(max = 500, message = "내용은 최대 500자까지 입력 가능합니다.")
         private String content;
-        private boolean isPublic;
+        @JsonProperty("isPostPublic")  // isPostPublic을 PostPublic으로 추론하는 에러에 대한 해결코드
+        private boolean isPostPublic;
         @NotBlank(message = "해시태그는 필수 입력 항목입니다.")
         @Size(max = 100, message = "해시태그는 최대 100자까지 입력 가능합니다.")
         private String hashtag;
@@ -34,7 +36,8 @@ public class PostRequestDto {
         private String title;
         @Size(max = 500, message = "내용은 최대 500자까지 입력 가능합니다.")
         private String content;
-        private Boolean isPublic;
+        @JsonProperty("isPostPublic")
+        private Boolean isPostPublic;
         @Size(max = 100, message = "해시태그는 최대 100자까지 입력 가능합니다.")
         private String hashtag;
     }

--- a/src/main/java/org/example/postory/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/org/example/postory/domain/post/dto/PostResponseDto.java
@@ -2,8 +2,6 @@ package org.example.postory.domain.post.dto;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +16,7 @@ public class PostResponseDto {
         private final Long id;
         private final String title;
         private final String content;
-        private final boolean isPublic;
+        private final boolean isPostPublic;
         private final String hashtag;
         private final int postLikeCount;
         private final String writer;
@@ -29,7 +27,7 @@ public class PostResponseDto {
             this.id = post.getId();
             this.title = post.getTitle();
             this.content = post.getContent();
-            this.isPublic = post.isPublic();
+            this.isPostPublic = post.isPostPublic();
             this.hashtag = post.getHashtag();
             this.postLikeCount = post.getPostLikeCount();
             this.writer = post.getUser().getName();
@@ -51,13 +49,8 @@ public class PostResponseDto {
         private String writer;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
-        @JsonIgnore // Lombok getter에 의해 자동 직렬화되는 걸 차단
-        private boolean isPublic;
+        private boolean isPostPublic;
 
-        @JsonProperty("isPublic")
-        public boolean getIsPublic() {
-            return isPublic;
-        }
 
 
         public static Get fromPostEntity(Post post) {
@@ -67,7 +60,7 @@ public class PostResponseDto {
                 .content(post.getContent())
                 .hashtag(post.getHashtag())
                 .postLikeCount(post.getPostLikeCount())
-                .isPublic(post.isPublic())
+                .isPostPublic(post.isPostPublic())
                 .isUpdated(!post.getCreatedAt().isEqual(post.getUpdatedAt()))
                 .writer(post.getUser().getName())
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/org/example/postory/domain/post/entity/Post.java
+++ b/src/main/java/org/example/postory/domain/post/entity/Post.java
@@ -31,7 +31,7 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private String content;
     @Column(nullable = false)
-    private boolean isPublic = true;
+    private boolean isPostPublic;
     @Column(nullable = false)
     private String hashtag;
     @Column(nullable = false)
@@ -52,8 +52,8 @@ public class Post extends BaseEntity {
             this.content = updatePost.getContent();
 
         }
-        if (updatePost.getIsPublic() != null) { // Dto Boolean 으로 설정하기!
-            this.isPublic = updatePost.getIsPublic();
+        if (updatePost.getIsPostPublic() != null) { // Dto Boolean 으로 설정하기!
+            this.isPostPublic = updatePost.getIsPostPublic();
         }
         if (updatePost.getHashtag() != null) {
             this.hashtag = updatePost.getHashtag();

--- a/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
@@ -23,7 +23,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             SELECT p FROM Post p
             WHERE p.id = :id
             AND (
-                p.isPublic = true
+                p.isPostPublic = true
                 OR (:userId IS NOT NULL AND p.user.id = :userId)
             )
             AND p.deletedAt IS NULL
@@ -31,7 +31,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findVisiblePost(@Param("id") Long id, @Param("userId") Long userId);
 
     //공개 게시글 + 삭제되지 않은 게시글 + 수정일 기준 최신순 정렬
-    List<Post> getAllByUser_IdAndDeletedAtIsNullAndIsPublicIsTrueOrderByUpdatedAt(Long userId);
+    List<Post> getAllByUser_IdAndDeletedAtIsNullAndIsPostPublicIsTrueOrderByUpdatedAt(Long userId);
 
     List<Post> getAllByUser_IdAndDeletedAtIsNullOrderByUpdatedAt(Long userId);
 
@@ -41,7 +41,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             SELECT p FROM Post p
             WHERE ((p.updatedAt < :cursorUpdatedAt)
             OR (p.updatedAt = :cursorUpdatedAt AND p.id < :cursorId))
-            AND p.isPublic = true
+            AND p.isPostPublic = true
             AND p.deletedAt IS NULL
             ORDER BY p.updatedAt DESC, p.id DESC
         """)
@@ -71,7 +71,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
              AND p.hashtag LIKE CONCAT('%', :hashTag, '%')
              AND p.postLikeCount >= :likeMinimum
              AND p.deletedAt IS NULL
-             AND p.isPublic = true
+             AND p.isPostPublic = true
         """)
     List<PostResponseDto.SearchList> findByHashTag(
         @Param("hashTag") String hashTag,
@@ -95,7 +95,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
              AND u.name LIKE CONCAT('%', :name, '%')
              AND p.postLikeCount >= :likeMinimum
              AND p.deletedAt IS NULL
-             AND p.isPublic = true
+             AND p.isPostPublic = true
         """)
     List<PostResponseDto.SearchList> findByMention(
         @Param("name") String name,
@@ -119,7 +119,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
              AND (p.title LIKE CONCAT('%', :keyword, '%') OR  p.content LIKE CONCAT('%', :keyword, '%'))
              AND p.postLikeCount >= :likeMinimum
              AND p.deletedAt IS NULL
-             AND p.isPublic = true
+             AND p.isPostPublic = true
         """)
     List<PostResponseDto.SearchList> findByKeyword(
         @Param("keyword") String keyword,

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -26,7 +26,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClient;
 
 
 @Service
@@ -60,7 +59,7 @@ public class PostServiceImpl implements PostService {
             .title(dto.getTitle())
             .content(dto.getContent())
             .hashtag(dto.getHashtag())
-            .isPublic(dto.isPublic())
+            .isPostPublic(dto.isPostPublic())
             .user(user) // DB에서 실제 user객체 조회하도록 수정
             .build();
         Post saved = postRepository.save(post);
@@ -149,7 +148,7 @@ public class PostServiceImpl implements PostService {
 
     //공개 게시글 + 삭제되지 않은 게시글 + 수정일 기준 최신순 정렬
     public List<NewsFeed> getVisiblePostsByUser(Long userId) {
-        return postRepository.getAllByUser_IdAndDeletedAtIsNullAndIsPublicIsTrueOrderByUpdatedAt(
+        return postRepository.getAllByUser_IdAndDeletedAtIsNullAndIsPostPublicIsTrueOrderByUpdatedAt(
                 userId)
             .stream().map(PostResponseDto.NewsFeed::new).collect(Collectors.toList());
     }

--- a/src/main/java/org/example/postory/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/org/example/postory/domain/user/dto/UserProfileResponseDto.java
@@ -2,6 +2,8 @@ package org.example.postory.domain.user.dto;
 
 
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import org.example.postory.domain.post.dto.PostResponseDto.NewsFeed;
 
@@ -18,7 +20,8 @@ public class UserProfileResponseDto {
 
     private final String introduction;
 
-    private final boolean isPublic;
+    @JsonProperty("isUserPublic")  // isUserPublic을 UserPublic으로 추론하는 에러에 대한 해결코드
+    private final boolean isUserPublic;
 
     private final int followingCnt;
 
@@ -30,24 +33,24 @@ public class UserProfileResponseDto {
 
     private final List<NewsFeed> postList;
 
-    public UserProfileResponseDto(Long id, String username, String introduction, boolean isPublic,
+    public UserProfileResponseDto(Long id, String username, String introduction, boolean isUserPublic,
         int followingCnt, int followerCnt, List<NewsFeed> postList) {
         this.id = id;
         this.username = username;
         this.introduction = introduction;
-        this.isPublic = isPublic;
+        this.isUserPublic = isUserPublic;
         this.followingCnt = followingCnt;
         this.followerCnt = followerCnt;
         this.postCount = postList.size();
         this.postList = postList;
     }
 
-    public UserProfileResponseDto(Long id, String username, String introduction, boolean isPublic,
+    public UserProfileResponseDto(Long id, String username, String introduction, boolean isUserPublic,
         int followingCnt, int followerCnt, boolean isFollowing, List<NewsFeed> postList) {
         this.id = id;
         this.username = username;
         this.introduction = introduction;
-        this.isPublic = isPublic;
+        this.isUserPublic = isUserPublic;
         this.followingCnt = followingCnt;
         this.followerCnt = followerCnt;
         this.isFollowing = isFollowing;

--- a/src/main/java/org/example/postory/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/org/example/postory/domain/user/dto/UserRequestDto.java
@@ -1,5 +1,6 @@
 package org.example.postory.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -23,7 +24,8 @@ public class UserRequestDto {
         @Size(max = 20, message = "비밀번호는 최대 20글자까지만 가능합니다.")
         private String password;
 
-        private Boolean isPublic;
+        @JsonProperty("isUserPublic")  // isUserPublic을 UserPublic으로 추론하는 에러에 대한 해결코드
+        private Boolean isUserPublic;
 
     }
 

--- a/src/main/java/org/example/postory/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/org/example/postory/domain/user/dto/UserResponseDto.java
@@ -1,5 +1,6 @@
 package org.example.postory.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.example.postory.domain.user.entity.User;
@@ -14,14 +15,15 @@ public class UserResponseDto {
         private final String name;
         private final String introduction;
         private final Boolean gender;
-        private final Boolean isPublic;
+        @JsonProperty("isUserPublic")  // isUserPublic을 UserPublic으로 추론하는 에러에 대한 해결코드
+        private final Boolean isUserPublic;
 
         public UpdateProfile(User user) {
             this.id = user.getId();
             this.name = user.getName();
             this.introduction = user.getIntroduction();
             this.gender = user.isGender();
-            this.isPublic = user.isPublic();
+            this.isUserPublic = user.isUserPublic();
         }
     }
 }

--- a/src/main/java/org/example/postory/domain/user/entity/User.java
+++ b/src/main/java/org/example/postory/domain/user/entity/User.java
@@ -37,7 +37,7 @@ public class User {
 
     @Setter
     @Column(nullable = false)
-    private boolean isPublic = true;
+    private boolean isUserPublic = true;
     @Column
     private String refreshToken;
 

--- a/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
@@ -93,7 +93,7 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByUserIdOrElseThrow(UserId);
 
         if (!loginUserId.equals(UserId) && !followingRepository.existsByUserIdAndFollowingUserId(
-            loginUserId, UserId) && !user.isPublic()) {
+            loginUserId, UserId) && !user.isUserPublic()) {
             throw new ApiException(FORBIDDEN_PROFILE);
         }
 
@@ -106,12 +106,12 @@ public class UserServiceImpl implements UserService {
             List<NewsFeed> posts = postService.getAllMyPosts(UserId);
 
             return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
-                user.isPublic(), followingCnt.intValue(), followerCnt.intValue(), posts);
+                user.isUserPublic(), followingCnt.intValue(), followerCnt.intValue(), posts);
         } else {
             List<NewsFeed> posts = postService.getVisiblePostsByUser(UserId);
 
             return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
-                user.isPublic(), followingCnt.intValue(), followerCnt.intValue(),
+                user.isUserPublic(), followingCnt.intValue(), followerCnt.intValue(),
                 followingRepository.existsByUserIdAndFollowingUserId(loginUserId, UserId), posts);
         }
     }
@@ -121,7 +121,7 @@ public class UserServiceImpl implements UserService {
      * 경우에만 변경됩니다.
      *
      * @param userId  업데이트 대상 사용자 ID
-     * @param profile 업데이트할 프로필 정보 (name, introduction, gender, password, isPublic)
+     * @param profile 업데이트할 프로필 정보 (name, introduction, gender, password, isPostPublic)
      * @return 업데이트된 사용자 프로필 정보
      */
     @Transactional
@@ -144,8 +144,8 @@ public class UserServiceImpl implements UserService {
             user.setPassword(PasswordEncoder.encode(profile.getPassword()));
         }
 
-        if (profile.getIsPublic() != null) {
-            user.setPublic(profile.getIsPublic());
+        if (profile.getIsUserPublic() != null) {
+            user.setUserPublic(profile.getIsUserPublic());
         }
 
         User savedUser = userRepository.save(user);
@@ -204,7 +204,7 @@ public class UserServiceImpl implements UserService {
 
         // 나 자신이 아니고 비공개이고 친구가 아니면 조회 불가
         if (!loginUserId.equals(userId)
-                && !user.isPublic()
+                && !user.isUserPublic()
                 && !followingRepository.existsByUserIdAndFollowingUserId(loginUserId, userId)) {
             throw new ApiException(FORBIDDEN_PROFILE);
         }
@@ -241,7 +241,7 @@ public class UserServiceImpl implements UserService {
 
         // 나 자신이 아니고 비공개이고 친구가 아니면 조회 불가
         if (!loginUserId.equals(userId)
-                && !user.isPublic()
+                && !user.isUserPublic()
                 && !followingRepository.existsByUserIdAndFollowingUserId(loginUserId, userId)) {
             throw new ApiException(FORBIDDEN_PROFILE);
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

fix/52 -> dev

### 변경 사항

isPublic 필드명을 인식하지 못하는 문제로
isPublic 필드명을 변경하였습니다. (db도 수정함)
post 엔터티의 isPublic을 isPostPublic으로,
user 엔터티의 isPublic을 isUserPublic으로.

`@JsonProperty("isPostPublic")` 는 isPostPublic을 PostPublic으로 추론하는 에러에 대한 해결코드입니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/940a3454-275b-480d-8668-4756652ba3db)
이전의 에러상황 (isPublic을 true로 게시물을 생성해도 response body에서는 false로 인식됨. 전달이 안되고있는 오류)

![image](https://github.com/user-attachments/assets/e83b9f43-b99b-4a3e-a02f-b235cbffa68b)
해결 : response body에 true값 전달됨

close #52 