### PR TITLE
[#50] feat: 비로그인 프로필/팔로잉/팔로워 조회

### DIFF
--- a/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
+++ b/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/auth/login", "/auth/reissue", "/users/signup", "/posts", "/comments")
+                .requestMatchers("/auth/login", "/auth/reissue", "/users/signup", "/posts", "/comments", "/users/profile/*")
                 .permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
+++ b/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
@@ -30,7 +30,14 @@ public class SecurityConfig {
             .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/auth/login", "/auth/reissue", "/users/signup", "/posts", "/comments", "/users/profile/*")
+                .requestMatchers("/auth/login",
+                        "/auth/reissue",
+                        "/users/signup",
+                        "/posts",
+                        "/comments",
+                        "/users/profile/*",
+                        "/users/following/*",
+                        "/users/followers/*")
                 .permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/org/example/postory/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/postory/domain/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
         @AuthenticationPrincipal UserDetails userDetails
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(userService.getProfile(Long.parseLong(userDetails.getUsername()), UserId));
+                .body(userService.getProfile(userDetails, UserId));
     }
 
     @PatchMapping("/profile")

--- a/src/main/java/org/example/postory/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/postory/domain/user/controller/UserController.java
@@ -73,7 +73,7 @@ public class UserController {
             @RequestParam(defaultValue = "10") int size
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userService.getFollowing(Long.parseLong(userDetails.getUsername()), userId, cursorId, size));
+                .body(userService.getFollowing(userDetails, userId, cursorId, size));
     }
 
     @GetMapping("/followers/{userId}")
@@ -84,7 +84,7 @@ public class UserController {
             @RequestParam(defaultValue = "10") int size
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userService.getFollowers(Long.parseLong(userDetails.getUsername()), userId, cursorId, size));
+                .body(userService.getFollowers(userDetails, userId, cursorId, size));
     }
 }
 

--- a/src/main/java/org/example/postory/domain/user/service/UserService.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import org.example.postory.domain.user.dto.UserRequestDto.UpdateProfile;
 import org.example.postory.domain.user.dto.UserResponseDto;
 import org.example.postory.domain.user.entity.User;
 import org.example.postory.global.common.pagination.CursorResponseDto;
+import org.springframework.security.core.userdetails.UserDetails;
 
 public interface UserService {
 
@@ -19,7 +20,9 @@ public interface UserService {
 
     User getByEmail(String email);
 
-    UserProfileResponseDto getProfile(Long authUserId, Long UserId);
+    UserProfileResponseDto getProfile(UserDetails userDetails, Long UserId);
+
+    UserProfileResponseDto getProfileByNonLoginUser(Long UserId);
 
     void follow(Long userId, Long followingId);
 

--- a/src/main/java/org/example/postory/domain/user/service/UserService.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserService.java
@@ -30,9 +30,9 @@ public interface UserService {
 
     UserResponseDto.UpdateProfile updateProfile(Long authUserId, UpdateProfile profile);
 
-    CursorResponseDto<FollowingResponseDto> getFollowing(Long authUserId, Long userId, Long cursorId, int size);
+    CursorResponseDto<FollowingResponseDto> getFollowing(UserDetails userDetails, Long userId, Long cursorId, int size);
 
-    CursorResponseDto<FollowingResponseDto> getFollowers(Long authUserId, Long userId, Long cursorId, int size);
+    CursorResponseDto<FollowingResponseDto> getFollowers(UserDetails userDetails, Long userId, Long cursorId, int size);
 
     User getById(Long authUserId);
 

--- a/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
@@ -24,6 +24,7 @@ import org.example.postory.global.error.ApiException;
 import org.example.postory.global.error.response.ErrorType;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -89,11 +90,44 @@ public class UserServiceImpl implements UserService {
      */
     @Transactional(readOnly = true)
     @Override
-    public UserProfileResponseDto getProfile(Long loginUserId, Long UserId) {
+    public UserProfileResponseDto getProfile(UserDetails userDetails, Long UserId) {
+        if (userDetails != null) {
+            Long loginUserId = Long.parseLong(userDetails.getUsername());
+            User user = userRepository.findByUserIdOrElseThrow(UserId);
+
+            if (!loginUserId.equals(UserId) && !followingRepository.existsByUserIdAndFollowingUserId(
+                    loginUserId, UserId) && !user.isPublic()) {
+                throw new ApiException(FORBIDDEN_PROFILE);
+            }
+
+            //팔로잉, 팔로워 수 구하기
+            Long followingCnt = followingRepository.countByUser_id(UserId);
+            Long followerCnt = followingRepository.countByFollowingUser_id(UserId);
+
+            if (loginUserId.equals(UserId)) {
+                //게시글 가져오기 - 자기자신의 프로필이라 isn't public 한 게시글도 다 불러옴
+                List<NewsFeed> posts = postService.getAllMyPosts(UserId);
+
+                return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
+                        user.isPublic(), followingCnt.intValue(), followerCnt.intValue(), posts);
+            } else {
+                List<NewsFeed> posts = postService.getVisiblePostsByUser(UserId);
+
+                return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
+                        user.isPublic(), followingCnt.intValue(), followerCnt.intValue(),
+                        followingRepository.existsByUserIdAndFollowingUserId(loginUserId, UserId), posts);
+            }
+        } else {
+            return getProfileByNonLoginUser(UserId);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public UserProfileResponseDto getProfileByNonLoginUser(Long UserId) {
         User user = userRepository.findByUserIdOrElseThrow(UserId);
 
-        if (!loginUserId.equals(UserId) && !followingRepository.existsByUserIdAndFollowingUserId(
-            loginUserId, UserId) && !user.isPublic()) {
+        if (!user.isPublic()) {
             throw new ApiException(FORBIDDEN_PROFILE);
         }
 
@@ -101,19 +135,10 @@ public class UserServiceImpl implements UserService {
         Long followingCnt = followingRepository.countByUser_id(UserId);
         Long followerCnt = followingRepository.countByFollowingUser_id(UserId);
 
-        if (loginUserId.equals(UserId)) {
-            //게시글 가져오기 - 자기자신의 프로필이라 isn't public 한 게시글도 다 불러옴
-            List<NewsFeed> posts = postService.getAllMyPosts(UserId);
+        List<NewsFeed> posts = postService.getVisiblePostsByUser(UserId);
 
-            return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
-                user.isPublic(), followingCnt.intValue(), followerCnt.intValue(), posts);
-        } else {
-            List<NewsFeed> posts = postService.getVisiblePostsByUser(UserId);
-
-            return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
-                user.isPublic(), followingCnt.intValue(), followerCnt.intValue(),
-                followingRepository.existsByUserIdAndFollowingUserId(loginUserId, UserId), posts);
-        }
+        return new UserProfileResponseDto(user.getId(), user.getName(), user.getIntroduction(),
+                user.isPublic(), followingCnt.intValue(), followerCnt.intValue(), false, posts);
     }
 
     /**

--- a/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/user/service/UserServiceImpl.java
@@ -83,7 +83,7 @@ public class UserServiceImpl implements UserService {
      * [Service] 프로필 조회 함수 1. controller에서 받아온 유저값 검증 2. 다른사람의 프로필 + 팔로우 안했음 + 상대방이 프로필 비공개 상태 ->
      * 403 3. 자신의 프로필 조회일 경우 - 비공개 개시글 표시o, 팔로잉 여부 표시x 4. 타인의 프로필 조회일 경우 - 비공개 게시글 표시x, 팔로잉 여부 표시o
      *
-     * @param loginUserId 현재 로그인 중인 유저 아이디
+     * @param userDetails 현재 로그인 중인 유저 정보
      * @param UserId      프로필 조회할 유저 아이디
      * @return UserProfileResponseDto 프로필 조회 내용 - 해당 사용자의 이름, 상태메시지, 팔로우 여부, 팔로우/팔로워 수, 게시글 목록
      * @throws 403 해당 페이지 접근 권한이 없기 때문에 예외 발생
@@ -221,20 +221,11 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-    public CursorResponseDto<FollowingResponseDto> getFollowing(Long loginUserId, Long userId, Long cursorId, int size) {
-        userRepository.findById(loginUserId)
-                .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+    public CursorResponseDto<FollowingResponseDto> getFollowing(UserDetails userDetails, Long userId, Long cursorId, int size) {
+        authenticationValidate(userDetails, userId);
 
-        // 나 자신이 아니고 비공개이고 친구가 아니면 조회 불가
-        if (!loginUserId.equals(userId)
-                && !user.isPublic()
-                && !followingRepository.existsByUserIdAndFollowingUserId(loginUserId, userId)) {
-            throw new ApiException(FORBIDDEN_PROFILE);
-        }
-
-        // 나 자신이면 조회 가능, 나 자신이 아니고 비공개가 아니면 조회 가능, 나 자신이 아니고 비공개인데 친구이면 조회 가능
+        // 로그인 - 나 자신이면 조회 가능, 나 자신이 아니고 공개면 조회 가능, 나 자신이 아니고 비공개인데 친구이면 조회 가능
+        // 비로그인 - 공개면 조회 가능
         if (cursorId == null) {
             cursorId = Long.MAX_VALUE;
         }
@@ -249,29 +240,16 @@ public class UserServiceImpl implements UserService {
                 .collect(Collectors.toList());
 
         // 다음 커서 설정
-        CursorDto nextCursor = null;
-        if (!followings.isEmpty()) {
-            Long lastId = followings.get(followings.size() - 1).getId();
-            nextCursor = new CursorDto(lastId); // 팔로잉 목록은 정렬 기준이 최근 업데이트된 순이 아니라 팔로잉 순서이기 때문에 id만 사용
-        }
+        CursorDto nextCursor = getCursorDto(followings);
 
         return CursorResponseDto.of(followingResponseDtos, nextCursor);
     }
 
-    public CursorResponseDto<FollowingResponseDto> getFollowers(Long loginUserId, Long userId, Long cursorId, int size) {
-        userRepository.findById(loginUserId)
-                .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
+    public CursorResponseDto<FollowingResponseDto> getFollowers(UserDetails userDetails, Long userId, Long cursorId, int size) {
+        authenticationValidate(userDetails, userId);
 
-        // 나 자신이 아니고 비공개이고 친구가 아니면 조회 불가
-        if (!loginUserId.equals(userId)
-                && !user.isPublic()
-                && !followingRepository.existsByUserIdAndFollowingUserId(loginUserId, userId)) {
-            throw new ApiException(FORBIDDEN_PROFILE);
-        }
-
-        // 나 자신이면 조회 가능, 나 자신이 아니고 비공개가 아니면 조회 가능, 나 자신이 아니고 비공개인데 친구이면 조회 가능
+        // 로그인 - 나 자신이면 조회 가능, 나 자신이 아니고 공개면 조회 가능, 나 자신이 아니고 비공개인데 친구이면 조회 가능
+        // 비로그인 - 공개면 조회 가능
         if (cursorId == null) {
             cursorId = Long.MAX_VALUE;
         }
@@ -279,20 +257,48 @@ public class UserServiceImpl implements UserService {
         Pageable pageable = PageRequest.of(0, size);
 
         // 커서 기반으로 팔로잉 유저 목록 조회 (최근에 팔로우한 순)
-        List<Following> followings = followingRepository.findFollowersByCursor(userId, cursorId, pageable);
+        List<Following> followers = followingRepository.findFollowersByCursor(userId, cursorId, pageable);
 
-        List<FollowingResponseDto> followingResponseDtos = followings.stream()
+        List<FollowingResponseDto> followingResponseDtos = followers.stream()
                 .map(f -> new FollowingResponseDto(f.getUser().getId(), f.getUser().getName()))
                 .collect(Collectors.toList());
 
-        // 다음 커서 설정
-        CursorDto nextCursor = null;
-        if (!followings.isEmpty()) {
-            Long lastId = followings.get(followings.size() - 1).getId();
-            nextCursor = new CursorDto(lastId); // 팔로잉 목록은 정렬 기준이 최근 업데이트된 순이 아니라 팔로잉 순서이기 때문에 id만 사용
-        }
+        CursorDto nextCursor = getCursorDto(followers);
 
         return CursorResponseDto.of(followingResponseDtos, nextCursor);
+    }
+
+    private static CursorDto getCursorDto(List<Following> followers) {
+        // 다음 커서 설정
+        CursorDto nextCursor = null;
+        if (!followers.isEmpty()) {
+            Long lastId = followers.get(followers.size() - 1).getId();
+            nextCursor = new CursorDto(lastId); // 팔로잉 목록은 정렬 기준이 최근 업데이트된 순이 아니라 팔로잉 순서이기 때문에 id만 사용
+        }
+        return nextCursor;
+    }
+
+    private void authenticationValidate(UserDetails userDetails, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+
+        if (userDetails != null) {  // 로그인
+            Long loginUserId = Long.parseLong(userDetails.getUsername());
+
+            userRepository.findById(loginUserId)
+                    .orElseThrow(() -> new ApiException(ErrorType.USER_NOT_FOUND));
+
+            // 나 자신이 아니고 비공개이고 친구가 아니면 조회 불가
+            if (!loginUserId.equals(userId)
+                    && !user.isPublic()
+                    && !followingRepository.existsByUserIdAndFollowingUserId(loginUserId, userId)) {
+                throw new ApiException(FORBIDDEN_PROFILE);
+            }
+        } else {  // 비로그인
+            if (!user.isPublic()) {
+                throw new ApiException(FORBIDDEN_PROFILE);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/50

### 변경 사항
- SecutiryConfig의 .permitAll()에 "/user/profile/*", "/user/following/*", "/user/followers/*" 추가했습니다.

### 구현 사항
- PATCH "/user/profile" 사용자 정보 수정 -> 무조건 로그인 해야됨 -> JWT 토큰 있어야 됨
- GET "/user/profile/*" 사용자 프로필 조회 
-> 비로그인 상태에서 조회할 때는 JWT 토큰 없어도 됨, 로그인 상태에서 조회할 때는 JWT 토큰 있어야 됨
- GET "/user/following/*", "/user/followers/*" 팔로잉/팔로워 목록 조회
-> 비로그인 상태에서 조회할 때는 JWT 토큰 없어도 됨, 로그인 상태에서 조회할 때는 JWT 토큰 있어야 됨
- UserDatails가 NULL인지 확인해서 JWT 토큰의 유무를 확인함

### 테스트 결과
**성공**
<img width="1033" alt="image" src="https://github.com/user-attachments/assets/0c5974c3-dab4-409c-aac2-24cc86e2609d" />

**실패**
<img width="1050" alt="image" src="https://github.com/user-attachments/assets/ed48123c-7d2c-41e8-8686-32849efced71" />