### PR TITLE
fix: #56 비로그인도 게시물 조회 가능

### DIFF
--- a/src/main/java/org/example/postory/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/postory/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -36,6 +36,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             return;
         }
 
+        // 토큰 없이도 허용 : 게시물 단건 조회, 뉴스피드 조회
+        String method = httpRequest.getMethod();
+        if (requestURI.startsWith("/posts") && "GET".equalsIgnoreCase(method)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         String token = resolveToken((HttpServletRequest) request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {

--- a/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
+++ b/src/main/java/org/example/postory/domain/auth/security/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/auth/login", "/auth/reissue", "/users/signup", "/posts", "/comments")
+                .requestMatchers("/auth/login", "/auth/reissue", "/users/signup", "/posts", "/posts/**", "/comments")
                 .permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

fix/56 -> dev

### 변경 사항

로그인하지않으면 게시물 조회가 안되는 부분 수정했습니다.
게시물 단건조회 / 전체조회(=뉴스피드조회) 모두 로그인하지않아도 공개글 보기 가능합니다.

### 테스트 결과
단건조회, 뉴스피드 조회 모두 토큰없이 성공
![image](https://github.com/user-attachments/assets/cce9a362-b6a6-437d-b223-353cc9945f6e)
![image](https://github.com/user-attachments/assets/17b7c982-7f74-4744-8694-67ec319c76c6)

