### PR TITLE
[#44] feat: 댓글 삭제 구현

### DIFF
--- a/src/main/java/org/example/postory/domain/comment/controller/CommentController.java
+++ b/src/main/java/org/example/postory/domain/comment/controller/CommentController.java
@@ -9,18 +9,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
 import java.time.LocalDateTime;
 import org.example.postory.domain.comment.dto.CommentResponseDto.CommentItem;
 import org.example.postory.global.common.pagination.CursorResponseDto;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/comments")
@@ -65,6 +58,16 @@ public class CommentController {
     ) {
         return ResponseEntity.status(HttpStatus.OK)
             .body(commentService.getComments(cursorCreatedAt, cursorId, postId, size));
+    }
+
+    // 댓글 삭제
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        commentService.deleteComment(Long.parseLong(userDetails.getUsername()), commentId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     // 좋아요

--- a/src/main/java/org/example/postory/domain/comment/entity/Comment.java
+++ b/src/main/java/org/example/postory/domain/comment/entity/Comment.java
@@ -17,6 +17,8 @@ import org.example.postory.domain.post.entity.Post;
 import org.example.postory.domain.user.entity.User;
 import org.example.postory.global.common.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -51,5 +53,9 @@ public class Comment extends BaseEntity {
 
     public void updateContent(String content){
         this.content = content;
+    }
+
+    public void markAsDeleted() { // soft delete
+        this.setDeletedAt(LocalDateTime.now());
     }
 }

--- a/src/main/java/org/example/postory/domain/comment/service/CommentService.java
+++ b/src/main/java/org/example/postory/domain/comment/service/CommentService.java
@@ -22,4 +22,7 @@ public interface CommentService {
 
     //댓글 수정
     CommentItem updateComment(Long authUserId, CommentRequestDto.CommentItem requestDto, Long commentId);
+
+    // 댓글 삭제
+    void deleteComment(Long authUserId, Long commentId);
 }

--- a/src/main/java/org/example/postory/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/comment/service/CommentServiceImpl.java
@@ -129,4 +129,14 @@ public class CommentServiceImpl implements CommentService {
         comment.updateContent(requestDto.getContents());
         return new CommentItem(comment);
     }
+
+    @Transactional
+    @Override
+    public void deleteComment(Long authUserId, Long commentId) {
+        Comment comment = commentRepository.getCommentByIdOrElseThrow(commentId);
+        if (!authUserId.equals(comment.getUser().getId())) {
+            throw new ApiException(ErrorType.FORBIDDEN_COMMENT);
+        }
+        comment.markAsDeleted();
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feat/44 -> dev

### 변경 사항

댓글 삭제 기능을 구현했습니다.
- soft delete 방식 사용
- 작성자만 삭제 가능하도록 권한 확인

### 테스트 결과
![image](https://github.com/user-attachments/assets/e84bb057-7f4c-46a2-a073-73b108e9e75c)
성공적으로 삭제
![image](https://github.com/user-attachments/assets/87df57c4-1728-405a-8435-5bdb485996d8)
작성자 본인이 아니면 삭제 못함

close #44 