### PR TITLE
[#76] fix: 게시글 수정 시 공백만 입력 불가

### DIFF
--- a/src/main/java/org/example/postory/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/org/example/postory/domain/post/dto/PostRequestDto.java
@@ -3,6 +3,7 @@ package org.example.postory.domain.post.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -33,12 +34,15 @@ public class PostRequestDto {
     public static class Update {
 
         @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
+        @Pattern(regexp = "^(?!\\s*$).+", message = "수정할 내용을 입력해주세요.")
         private String title;
         @Size(max = 500, message = "내용은 최대 500자까지 입력 가능합니다.")
+        @Pattern(regexp = "^(?!\\s*$).+", message = "수정할 내용을 입력해주세요.")
         private String content;
         @JsonProperty("isPostPublic")
         private Boolean isPostPublic;
         @Size(max = 100, message = "해시태그는 최대 100자까지 입력 가능합니다.")
+        @Pattern(regexp = "^(?!\\s*$).+", message = "수정할 내용을 입력해주세요.")
         private String hashtag;
     }
     

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -129,6 +129,7 @@ public class PostServiceImpl implements PostService {
 
     // 게시물 수정
     @Override
+    @Transactional
     public void updatePost(long id, PostRequestDto.Update updatePost, Long userId) {
 
         Post post = postRepository.findByIdOrElseThrow(id);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feature76 -> dev

### 변경 사항

+ 게시글 수정 시 공백만 입력 오류 방지하기 위해 @Pattern 추가

### 테스트 결과

<img width="1265" src="https://github.com/user-attachments/assets/e0121385-7eb3-4b41-9b1d-83ca75f06713" />


close #76 