### PR TITLE
[#75] fix: 로그인하지 않으면 게시물 단건조회 안되는 에러 해결

### DIFF
--- a/src/main/java/org/example/postory/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/postory/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -36,13 +36,6 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             return;
         }
 
-        // 토큰 없이도 허용 : 게시물 단건 조회, 뉴스피드 조회
-        String method = httpRequest.getMethod();
-        if (requestURI.startsWith("/posts") && "GET".equalsIgnoreCase(method)) {
-            chain.doFilter(request, response);
-            return;
-        }
-
         String token = resolveToken((HttpServletRequest) request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {

--- a/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/example/postory/domain/post/repository/PostRepository.java
@@ -26,7 +26,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             WHERE p.id = :id
             AND (
                 p.isPostPublic = true
-                OR (:userId IS NOT NULL AND p.user.id = :userId)
+                OR p.user.id = :userId
             )
             AND p.deletedAt IS NULL
         """)

--- a/src/main/java/org/example/postory/domain/post/service/PostService.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostService.java
@@ -12,7 +12,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 public interface PostService {
 
     // 게시물 id와 사용자 id로 게시물 조회
-    Post getPostById(long postId, Long userId);
+//    Post getPostById(long postId, Long userId);
 
     // 게시물 단건 조회
     PostResponseDto.GetPost getPost(long id, UserDetails userDetails, LocalDateTime cursorCreatedAt, Long cursorId, int size);

--- a/src/main/java/org/example/postory/domain/post/service/PostService.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostService.java
@@ -11,9 +11,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 public interface PostService {
 
-    // 게시물 id와 사용자 id로 게시물 조회
-//    Post getPostById(long postId, Long userId);
-
     // 게시물 단건 조회
     PostResponseDto.GetPost getPost(long id, UserDetails userDetails, LocalDateTime cursorCreatedAt, Long cursorId, int size);
 

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -42,15 +42,6 @@ public class PostServiceImpl implements PostService {
 
     private final int LIKE_MINIMUM = 0;
 
-
-//    @Override
-//    public Post getPostById(long postId, Long userId) {
-//        return postRepository.findVisiblePost(postId, userId)
-//            .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
-//        // 결과는 Optional<Post> 형식으로 반환되며, 값이 존재하면 그 값을 꺼내서 return
-//        // 빈 Optional이 나오면 orElseThrow로 값 던지기
-//    }
-
     @Override
     public PostResponseDto.GetPost getPost(long id, UserDetails userDetails, LocalDateTime cursorCreatedAt, Long cursorId, int size) {
         Long userId = null;

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -53,7 +53,7 @@ public class PostServiceImpl implements PostService {
             }
         }
         Post findPost = postRepository.findVisiblePost(id, userId)
-                .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
+            .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
         CursorResponseDto<CommentItem> comments = commentService.getComments(cursorCreatedAt, cursorId, id, size, userDetails);
 
         return new PostResponseDto.GetPost(findPost, comments);

--- a/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/org/example/postory/domain/post/service/PostServiceImpl.java
@@ -43,22 +43,26 @@ public class PostServiceImpl implements PostService {
     private final int LIKE_MINIMUM = 0;
 
 
-    @Override
-    public Post getPostById(long postId, Long userId) {
-        return postRepository.findVisiblePost(postId, userId)
-            .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
-        // 결과는 Optional<Post> 형식으로 반환되며, 값이 존재하면 그 값을 꺼내서 return
-        // 빈 Optional이 나오면 orElseThrow로 값 던지기
-    }
+//    @Override
+//    public Post getPostById(long postId, Long userId) {
+//        return postRepository.findVisiblePost(postId, userId)
+//            .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
+//        // 결과는 Optional<Post> 형식으로 반환되며, 값이 존재하면 그 값을 꺼내서 return
+//        // 빈 Optional이 나오면 orElseThrow로 값 던지기
+//    }
 
     @Override
     public PostResponseDto.GetPost getPost(long id, UserDetails userDetails, LocalDateTime cursorCreatedAt, Long cursorId, int size) {
-        // 로그인 한 사용자 아이디 조회
-        Long userId = Long.valueOf(userDetails.getUsername());
-
+        Long userId = null;
+        if (userDetails != null) {
+            try {
+                userId = Long.valueOf(userDetails.getUsername());
+            } catch (NumberFormatException e) {
+                throw new ApiException(ErrorType.UNAUTHORIZED_USER);
+            }
+        }
         Post findPost = postRepository.findVisiblePost(id, userId)
-            .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
-
+                .orElseThrow(() -> new ApiException(ErrorType.POST_NOT_FOUND));
         CursorResponseDto<CommentItem> comments = commentService.getComments(cursorCreatedAt, cursorId, id, size, userDetails);
 
         return new PostResponseDto.GetPost(findPost, comments);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

fix/75 -> dev

### 변경 사항
- 로그인하지 않아도(userId==null) 게시물 조회가 가능해야하므로, NPE를 방지하기 위한 코드 추가
- JwtAuthenticationFilter에 기존에 제가 추가했던 코드는 최종 로직을 고려하여 삭제하였습니다

### 테스트 결과
정상작동 확인하였습니다

close #75 
